### PR TITLE
Classfeature and Classability hotfix for 5e conversions

### DIFF
--- a/FGE.Models/Converter.cs
+++ b/FGE.Models/Converter.cs
@@ -43,7 +43,7 @@ namespace FGE.Models
 
             this.PostProcessors.Add(new UpdateReferenceLinks());
             this.PostProcessors.Add(new AddKeywordsToRefPages());
-            this.PostProcessors.Add(new UpdateClassFeatureRefernceLinks());
+            this.PostProcessors.Add(new UpdateClassAbilityReferenceLinks());
 
             DB = XElement.Load(Path.Combine(CampaignFolder, "db.xml"));
         }

--- a/FGE.Models/PostProcessors/UpdateClassAbilityReferenceLinks.cs
+++ b/FGE.Models/PostProcessors/UpdateClassAbilityReferenceLinks.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace FGE.Models.PostProcessors
+{
+    // Only run on 5e conversions
+    internal class UpdateClassAbilityReferenceLinks : IPostProcessor
+    {
+        public void Process(Converter converter)
+        {
+            var links = converter.Export
+                .Descendants("link")
+                .Where(e => e.Attribute("class") != null &&
+                            (e.Attribute("class")?.Value == "reference_classability" ||
+                            e.Attribute("class")?.Value == "reference_classfeature" ) && 
+                            !string.IsNullOrEmpty(e.Attribute("recordname")?.Value));
+            foreach (var link in links)
+            {
+                var config = converter.Config.RecordTypes.FirstOrDefault(r => r.RecordType == "class");
+                string replace = "reference." + config.ReferencePath;
+
+                string newVal = Regex.Replace(link.Attribute("recordname").Value, @"^(class)", replace);
+                link.Attribute("recordname").SetValue(newVal);
+            }
+        }
+
+        public bool ShouldRun(Converter converter)
+        {
+            return converter.Config.Ruleset == "5E" && converter.Config.ReadOnly == true;
+        }
+    }
+}

--- a/FGE.Models/PostProcessors/UpdateClassFeatureReferenceLinks.cs
+++ b/FGE.Models/PostProcessors/UpdateClassFeatureReferenceLinks.cs
@@ -8,7 +8,8 @@ using System.Threading.Tasks;
 namespace FGE.Models.PostProcessors
 {
     // Should only run on 5e conversions
-    internal class UpdateClassFeatureRefernceLinks : IPostProcessor
+    // Currently unused. Use UpdateClassAbilityReferenceLinks post processor instead
+    internal class UpdateClassFeatureReferenceLinks : IPostProcessor
     {
         public void Process(Converter converter)
         {


### PR DESCRIPTION
Fixed issue where class feature and class ability links in 5e were not converting correctly when exporting a read-only module