### PR TITLE
Fixed tablereference read-only conversion

### DIFF
--- a/FGE.Models/Converter.cs
+++ b/FGE.Models/Converter.cs
@@ -44,6 +44,7 @@ namespace FGE.Models
             this.PostProcessors.Add(new UpdateReferenceLinks());
             this.PostProcessors.Add(new AddKeywordsToRefPages());
             this.PostProcessors.Add(new UpdateClassAbilityReferenceLinks());
+            this.PostProcessors.Add(new UpdateTableReferenceLinks());
 
             DB = XElement.Load(Path.Combine(CampaignFolder, "db.xml"));
         }

--- a/FGE.Models/PostProcessors/UpdateTableReferenceLinks.cs
+++ b/FGE.Models/PostProcessors/UpdateTableReferenceLinks.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace FGE.Models.PostProcessors
+{
+    // Only run on 5e conversions
+    internal class UpdateTableReferenceLinks : IPostProcessor
+    {
+        public void Process(Converter converter)
+        {
+            var links = converter.Export
+                .Descendants("resultlink")
+                .Where(e => e.Element("class") != null &&
+                            e.Element("recordname") != null);
+            foreach (var link in links)
+            {
+                var recordclass = link.Element("class").Value;
+                var config = converter.Config.RecordTypes.FirstOrDefault(r => r.RecordType == recordclass);
+
+                string replace = "reference." + config.ReferencePath;
+                string regex = $"^({recordclass})";
+                string newVal = Regex.Replace(link.Element("recordname").Value, regex, replace);
+                link.Element("recordname").SetValue(newVal);
+            }
+        }
+
+        public bool ShouldRun(Converter converter)
+        {
+            return converter.Config.Ruleset == "5E" && converter.Config.ReadOnly == true;
+        }
+    }
+}


### PR DESCRIPTION
Fixed issue where reference links in tables weren't getting replaced with their read-only version.